### PR TITLE
Fixes Firefox for Android buttons not looking right

### DIFF
--- a/css/kraken.css
+++ b/css/kraken.css
@@ -639,6 +639,7 @@ input[type="button"].btn-block {
 
 button,
 .btn {
+  background-image: none;
   cursor: pointer;
   text-align: center;
   vertical-align: middle;

--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -77,6 +77,7 @@ input[type="button"].btn-block {
 
 button,
 .btn {
+	background-image: none;
 	cursor: pointer;
 	text-align: center;
 	vertical-align: middle;


### PR DESCRIPTION
By default, Firefox for Android applies a background-image to buttons,
making them look different than in other browsers.

[Before](https://f.cloud.github.com/assets/4894086/2180424/211ac3da-9718-11e3-89b8-4f12088e4e91.png)
[After](https://f.cloud.github.com/assets/4894086/2180425/36b8f9aa-9718-11e3-988d-1e88c20e1182.png)

It looks like bootstrap had run into this issue before as well : https://github.com/twbs/bootstrap/pull/9567
