### PR TITLE
Updated link styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Kraken is free to use under the [MIT License](http://gomakethings.com/mit/).
 
 Kraken uses [semantic versioning](http://semver.org/).
 
+* v5.5.0 - January 7, 2014
+	* Removed `:visited` and `:active` link styling to prevent specificity issues.
 * v5.4.0 - January 7, 2014
 	* Added `$color-info` variable.
 * v5.3.0 - January 7, 2014

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "Kraken",
-	"version": "5.4.0",
+	"version": "5.5.0",
 	"description": "A lightweight front-end boilerplate",
 	"main": "./",
 	"author": {

--- a/src/sass/components/_typography.scss
+++ b/src/sass/components/_typography.scss
@@ -30,16 +30,14 @@ p {
  * Hyperlink styling
  */
 
-a,
-a:visited {
+a {
 	color: $color-primary;
 	text-decoration: none;
 	word-wrap: break-word;
 }
 
 a:hover,
-a:focus,
-a:active {
+a:focus {
 	color: darken( $color-primary, 15% );
 	text-decoration: underline;
 }


### PR DESCRIPTION
Removed `:active` and `:visited` to avoid specificity conflicts.
